### PR TITLE
fix: debian: intel/sof-ace-tplg link in preinst

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+linux-firmware (20250310.git9e1370d3-0ubuntu1deepin3) unstable; urgency=medium
+
+  * clean the sof-ace-tplg dir in preinst for we don`t know the old dir is link or in dir file.
+  
+ -- Wentao Guan <guanwentao@uniontech.com>  Thu, 24 Jul 2025 21:02:00 +0800
+
 linux-firmware (20250310.git9e1370d3-0ubuntu1deepin2) unstable; urgency=medium
 
   * Fixing conflicts between symbolic links modifying files and symbolic links modifying directories.

--- a/debian/linux-firmware.preinst
+++ b/debian/linux-firmware.preinst
@@ -8,6 +8,10 @@ case "$1" in
 		if [ -L /lib/firmware/ath11k/WCN6855/hw2.1 ]; then
 			rm -f /lib/firmware/ath11k/WCN6855/hw2.1
 		fi
+		# Fix intel/sof-ace-tplg link diff in file and dir
+		if [ -e /lib/firmware/intel/sof-ace-tplg ]; then
+			rm -r /lib/firmware/intel/sof-ace-tplg
+		fi
 		;;
 esac
 


### PR DESCRIPTION
We don`t know the older version dir state,
remove the dir to solve the conflict cases when dpkg install a dir link to a dir have links, or a dir have links to dir.

The first one cause slient error,cause fw load failed and the next one casue dpkg installed error.

Closes:https://bbs.deepin.org.cn/zh/post/289741
Closes:https://bbs.deepin.org.cn/zh/post/289745